### PR TITLE
make freq drop invariant to input dtype #13

### DIFF
--- a/tests/test_gpu_augmentations.py
+++ b/tests/test_gpu_augmentations.py
@@ -63,6 +63,21 @@ def test_freq_drop_no_nan_and_inplace():
     assert torch.isnan(out).logical_not().all()
 
 
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float8_e4m3fn, torch.float16],
+    ids=["bf16", "fp8", "fp16"],
+)
+def test_freq_drop_low_precision_dtypes(dtype):
+    try:
+        waveforms = _waveforms(dtype=torch.float32).to(dtype)
+    except RuntimeError:
+        pytest.skip(f"{dtype} not supported on {DEVICE}")
+    out = freq_drop(waveforms)
+    assert out.shape == waveforms.shape
+    assert out.dtype == dtype
+
+
 def test_add_noise_with_mock_loader():
     """Test add_noise with a mock NoiseLoader."""
     from unittest.mock import MagicMock

--- a/uv.lock
+++ b/uv.lock
@@ -702,7 +702,7 @@ wheels = [
 
 [[package]]
 name = "wav2aug"
-version = "0.0.3"
+version = "0.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "torch" },

--- a/wav2aug/gpu/frequency_dropout.py
+++ b/wav2aug/gpu/frequency_dropout.py
@@ -159,34 +159,38 @@ def freq_drop(
     _FILTER_LEN: Final[int] = 101
     _PAD: Final[int] = _FILTER_LEN // 2
 
-    # Start with delta function (identity filter)
-    drop_filter = torch.zeros(1, _FILTER_LEN, 1, device=device, dtype=dtype)
+    # always use float32 for filter construction to avoid precision issues
+    # (e.g. 1e-12 clamp rounds to 0.0 in float16, violating notch_freq > 0)
+    filter_dtype = torch.float32
+
+    # start with delta function (identity filter)
+    drop_filter = torch.zeros(1, _FILTER_LEN, 1, device=device, dtype=filter_dtype)
     drop_filter[0, _PAD, 0] = 1.0
 
-    # Sample frequencies and build composite filter by convolving notch kernels
+    # sample frequencies and build composite filter by convolving notch kernels
     drop_frequencies = (
-        torch.rand(band_count, device=device, dtype=dtype) * rng + bound_low
+        torch.rand(band_count, device=device, dtype=filter_dtype) * rng + bound_low
     )
-    drop_frequencies = drop_frequencies.clamp(min=1e-12)
+
+    max_freq = max(1e-12, 1.0 - 2.0 * width - 1e-6)
+    drop_frequencies = drop_frequencies.clamp(min=1e-12, max=max_freq)
 
     for i in range(band_count):
         freq = drop_frequencies[i].item()
-        notch_kernel = _notch_filter(freq, _FILTER_LEN, width, device, dtype)
+        notch_kernel = _notch_filter(freq, _FILTER_LEN, width, device, filter_dtype)
         drop_filter = _convolve1d(drop_filter, notch_kernel, _PAD)
 
-    # Apply filter to entire batch at once
+    # apply filter to entire batch at once
     # waveforms: [B, T] -> [B, T, 1] for _convolve1d
-    dropped = waveforms.unsqueeze(-1)
+    # keep filter and convolution in float32 for dtypes that don't support conv1d
+    dropped = waveforms.to(filter_dtype).unsqueeze(-1)
     dropped = _convolve1d(dropped, drop_filter, _PAD)
     dropped = dropped.squeeze(-1)
 
     if clamp_abs is not None and clamp_abs > 0:
         dropped = dropped.clamp_(-clamp_abs, clamp_abs)
 
-    dropped = torch.nan_to_num(dropped, nan=0.0, posinf=0.0, neginf=0.0)
-
-    # Copy result back (in-place semantics)
-    waveforms.copy_(dropped)
+    waveforms.copy_(dropped.to(dtype))
     return waveforms
 
 


### PR DESCRIPTION
An assertion error is was being caused by a training recipe that runs in fp16.

When we clamp the filter at 1e-12 in fp16, it gets casted to 0, causing an assertion error when computing the notch_filter. This PR changes functionality to do the filter construction and convolution in fp32 and then cast back to input dtype to avoid any issues. The overhead in memory is trivial imo, people are training in fp16 or fp8 to save mem on the model side of things anyways.

closes #13 