### PR TITLE
removed in-place

### DIFF
--- a/tests/test_gpu_augmentations.py
+++ b/tests/test_gpu_augmentations.py
@@ -24,20 +24,16 @@ def _waveforms(
     return torch.randn(batch, time, device=DEVICE, dtype=dtype)
 
 
-def test_rand_amp_clip_inplace_preserves_shape():
+def test_rand_amp_clip_preserves_shape():
     waveforms = _waveforms()
-    ptr = waveforms.data_ptr()
     out = rand_amp_clip(waveforms)
-    assert out.data_ptr() == ptr
     assert out.shape == (waveforms.size(0), waveforms.size(1))
     assert torch.isfinite(out).all()
 
 
-def test_rand_amp_scale_inplace_preserves_shape():
+def test_rand_amp_scale_preserves_shape():
     waveforms = _waveforms()
-    ptr = waveforms.data_ptr()
     out = rand_amp_scale(waveforms)
-    assert out.data_ptr() == ptr
     assert out.shape == (waveforms.size(0), waveforms.size(1))
     assert torch.isfinite(out).all()
 
@@ -55,11 +51,9 @@ def test_chunk_swap_outputs_permutation():
     )
 
 
-def test_freq_drop_no_nan_and_inplace():
+def test_freq_drop_no_nan():
     waveforms = _waveforms()
-    ptr = waveforms.data_ptr()
     out = freq_drop(waveforms)
-    assert out.data_ptr() == ptr
     assert torch.isnan(out).logical_not().all()
 
 
@@ -83,23 +77,19 @@ def test_add_noise_with_mock_loader():
     from unittest.mock import MagicMock
 
     waveforms = torch.ones(2, 128, device=DEVICE, dtype=torch.float32)
-    ptr = waveforms.data_ptr()
 
     # Create mock loader that returns zeros
     mock_loader = MagicMock()
     mock_loader.get_batch.return_value = torch.zeros(2, 128)
 
     out = add_noise(waveforms, mock_loader, snr_low=0.0, snr_high=0.0)
-    assert out.data_ptr() == ptr
     assert torch.isfinite(out).all()
     mock_loader.get_batch.assert_called_once_with(2, 128)
 
 
 def test_add_babble_noise_identity_for_singleton_batch():
     waveforms = torch.full((1, 64), 2.0, device=DEVICE, dtype=torch.float32)
-    ptr = waveforms.data_ptr()
     out = add_babble_noise(waveforms, snr_low=0.0, snr_high=0.0)
-    assert out.data_ptr() == ptr
     assert torch.allclose(out, torch.full_like(out, 2.0))
 
 
@@ -123,7 +113,6 @@ def test_speed_perturb_adjusts_length():
 def test_time_dropout_zeroes_segments():
     waveforms = torch.ones(2, 64, device=DEVICE, dtype=torch.float32)
     lengths = torch.ones(2, device=DEVICE, dtype=torch.float32)
-    ptr = waveforms.data_ptr()
     out = time_dropout(
         waveforms,
         lengths=lengths,
@@ -132,7 +121,6 @@ def test_time_dropout_zeroes_segments():
         chunk_size_low=2,
         chunk_size_high=2,
     )
-    assert out.data_ptr() == ptr
     zeros_per_row = (out == 0).sum(dim=1)
     assert torch.all(zeros_per_row >= 2)
 

--- a/wav2aug/gpu/amplitude_clipping.py
+++ b/wav2aug/gpu/amplitude_clipping.py
@@ -23,7 +23,7 @@ def rand_amp_clip(
         eps: Numerical floor to avoid division by zero.
 
     Returns:
-        The input ``waveforms`` tensor, modified in-place.
+        Clipped waveforms.
     """
     if waveforms.ndim != 2:
         raise AssertionError("expected waveforms shaped [batch, time]")
@@ -37,7 +37,7 @@ def rand_amp_clip(
     # Normalize to [-1, 1] by absolute max
     abs_max = waveforms.abs().amax(dim=1, keepdim=True)
     abs_max = abs_max.clamp_min(eps)
-    waveforms.div_(abs_max)
+    out = waveforms / abs_max
 
     # Single clip value for entire batch (matches SpeechBrain)
     clip = torch.rand(1, device=device, dtype=dtype)
@@ -45,11 +45,11 @@ def rand_amp_clip(
     clip = clip.clamp_min(eps)
 
     # Apply clipping
-    waveforms.clamp_(-clip, clip)
+    out = out.clamp(-clip, clip)
 
     # Restore amplitude scaled by clip factor
-    waveforms.mul_(abs_max / clip)
-    return waveforms
+    out = out * (abs_max / clip)
+    return out
 
 
 __all__ = ["rand_amp_clip"]

--- a/wav2aug/gpu/amplitude_scaling.py
+++ b/wav2aug/gpu/amplitude_scaling.py
@@ -21,7 +21,7 @@ def rand_amp_scale(
         amp_high: Maximum amplitude scale factor.
 
     Returns:
-        The input ``waveforms`` tensor, modified in-place.
+        Scaled waveforms.
     """
     if waveforms.ndim != 2:
         raise AssertionError("expected waveforms shaped [batch, time]")
@@ -36,13 +36,12 @@ def rand_amp_scale(
     abs_max = waveforms.abs().amax(dim=1, keepdim=True)
     # Avoid division by zero for silent signals
     abs_max = abs_max.clamp_min(1e-14)
-    waveforms.div_(abs_max)
+    out = waveforms / abs_max
 
     # Per-sample scaling factors
     scales = torch.rand((waveforms.size(0), 1), device=device, dtype=dtype)
     scales = scales * (amp_high - amp_low) + amp_low
-    waveforms.mul_(scales)
-    return waveforms
+    return out * scales
 
 
 __all__ = ["rand_amp_scale"]

--- a/wav2aug/gpu/frequency_dropout.py
+++ b/wav2aug/gpu/frequency_dropout.py
@@ -188,10 +188,9 @@ def freq_drop(
     dropped = dropped.squeeze(-1)
 
     if clamp_abs is not None and clamp_abs > 0:
-        dropped = dropped.clamp_(-clamp_abs, clamp_abs)
+        dropped = dropped.clamp(-clamp_abs, clamp_abs)
 
-    waveforms.copy_(dropped.to(dtype))
-    return waveforms
+    return dropped.to(dtype)
 
 
 __all__ = ["freq_drop"]

--- a/wav2aug/gpu/noise_addition.py
+++ b/wav2aug/gpu/noise_addition.py
@@ -167,14 +167,9 @@ def _mix_noise(
     signal_rms = waveforms.pow(2).mean(dim=1, keepdim=True).sqrt().clamp_min(_EPS)
     noise_rms = noise.pow(2).mean(dim=1, keepdim=True).sqrt().clamp_min(_EPS)
 
-    # Scale the clean signal by (1 - noise_amplitude_factor)
-    waveforms.mul_(1.0 - noise_amplitude_factor)
-
-    # Compute target noise amplitude and scale noise accordingly
+    # Mix signal and noise at target SNR
     noise_scale = (noise_amplitude_factor * signal_rms) / noise_rms
-    waveforms.add_(noise * noise_scale)
-
-    return waveforms
+    return waveforms * (1.0 - noise_amplitude_factor) + noise * noise_scale
 
 
 @torch.no_grad()

--- a/wav2aug/gpu/polarity_inversion.py
+++ b/wav2aug/gpu/polarity_inversion.py
@@ -32,10 +32,10 @@ def invert_polarity(
 
     batch = waveforms.size(0)
 
+    # Build a per-sample sign multiplier: -1 for flipped, +1 for kept
     flips = torch.rand(batch, device=waveforms.device) < prob
-    if flips.any():
-        waveforms[flips] *= -1
-    return waveforms
+    signs = torch.where(flips, -1.0, 1.0).unsqueeze(1)
+    return waveforms * signs
 
 
 __all__ = ["invert_polarity"]

--- a/wav2aug/gpu/time_dropout.py
+++ b/wav2aug/gpu/time_dropout.py
@@ -56,7 +56,7 @@ def time_dropout(
         base_sample_rate: Reference sample rate for scaling chunk lengths.
 
     Returns:
-        Waveforms with time dropout applied (in-place modification).
+        Waveforms with time dropout applied.
 
     Raises:
         AssertionError: If waveforms are not 2D.
@@ -150,9 +150,7 @@ def time_dropout(
     drop_mask = chunk_mask.any(dim=1)  # [B, T]
 
     # Zero out masked positions
-    waveforms.masked_fill_(drop_mask, 0.0)
-
-    return waveforms
+    return waveforms.masked_fill(drop_mask, 0.0)
 
 
 __all__ = ["time_dropout"]


### PR DESCRIPTION
We were previously doing some of the augmentation operations in place. Although this did save memory in some places, it is probably ill-advised to modify people's waveforms in place by default. This PR makes all augmentations out-of-place. The memory overhead on the augmentations that were using it is minimal.